### PR TITLE
fix: exception raised while stopping the worker should not block the …

### DIFF
--- a/async_processor/app.py
+++ b/async_processor/app.py
@@ -90,9 +90,13 @@ class ProcessorApp:
             )
         yield
         logger.info("Shutting down worker")
-        if self._worker:
-            self._worker.stop()
-            await worker_task
+
+        try:
+            if self._worker:
+                self._worker.stop()
+                await worker_task
+        except Exception:
+            logger.exception("Exception raised while stopping the worker.")
 
         if os.getenv("PROMETHEUS_MULTIPROC_DIR"):
             multiprocess.mark_process_dead(os.getpid())


### PR DESCRIPTION
…rest of the clean up flow

ensure we are marking the process as dead on prom client