### PR TITLE
refactor and fix: retry, result publish and metric collection

### DIFF
--- a/async_processor/prometheus_metrics.py
+++ b/async_processor/prometheus_metrics.py
@@ -89,13 +89,14 @@ class collect_total_message_processing_metrics:
     def __exit__(self, exc_type, exc_value, exc_tb):
         end = _perf_counter_ms()
         _MESSAGES_IN_PROCESS.dec(1)
-        if self._output_status is not None:
+
+        if exc_value is not None:
+            status = ProcessStatus.FAILED.value
+        elif self._output_status is not None:
             status = self._output_status
         else:
-            if exc_value is None:
-                status = ProcessStatus.SUCCESS.value
-            else:
-                status = ProcessStatus.FAILED.value
+            status = ProcessStatus.SUCCESS.value
+
         _MESSAGES_PROCESSED.labels(status=status).inc(1)
         message_processing_time = end - self._start
         logger.debug(

--- a/async_processor/worker.py
+++ b/async_processor/worker.py
@@ -238,13 +238,14 @@ class _Worker:
                     received_at_epoch_ns - input_message.published_at_epoch_ns
                 )
 
-            if output and serialized_output_message and input_message:
-                await _publish_response(
-                    serialized_output_message=serialized_output_message,
-                    request_id=input_message.request_id,
-                    output=output,
-                )
-            elif not output:
+            if output:
+                if serialized_output_message and input_message:
+                    await _publish_response(
+                        serialized_output_message=serialized_output_message,
+                        request_id=input_message.request_id,
+                        output=output,
+                    )
+            else:
                 logger.debug(
                     "Skipping publishing response as output config is not present"
                 )

--- a/async_processor/worker.py
+++ b/async_processor/worker.py
@@ -7,6 +7,7 @@ import signal
 import string
 import time
 from contextlib import AsyncExitStack
+from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
 from async_processor.logger import logger
@@ -29,46 +30,89 @@ if TYPE_CHECKING:
     from async_processor.processor import AsyncProcessorWrapper
 
 
-async def _retry_with_exponential_backoff(
+async def _try_with_exponential_backoff(
     coroutine: Callable,
+    args: Tuple = None,
     kwargs: Optional[Dict] = None,
-    num_retries: int = 5,
+    # The coroutine will always be awaited at least once.
+    # regardless of num_tries.
+    num_tries: int = 2,
     # base_ms needs to be more than 1. sub-ms does not work.
     base_ms: int = 5,
     jitter_ms: Optional[Tuple[int, int]] = (0, 100),
     max_wait_ms: float = 2000,
     retry_exceptions=(Exception,),
 ) -> Any:
-    retry_count = 0
+    try_count = 0
     exceptions_raised = []
 
     kwargs = kwargs or {}
+    args = args or ()
 
     execution_name = getattr(coroutine, "__name__", "NO_NAME")
     execution_name = (
         f"{execution_name}-{''.join(random.choices(string.ascii_letters, k=4))}"
     )
 
-    while retry_count <= num_retries:
+    while True:
         try:
-            return await coroutine(**kwargs)
+            return await coroutine(*args, **kwargs)
         except retry_exceptions as ex:
             exceptions_raised.append(ex)
-            retry_count += 1
-            sleep_ms = base_ms**retry_count
+            try_count += 1
+
+            if try_count > num_tries:
+                break
+
+            sleep_ms = base_ms**try_count
             if jitter_ms:
                 sleep_ms += random.uniform(*jitter_ms)
             sleep_ms = min(sleep_ms, max_wait_ms)
 
             logger.warning(
-                "Execution=%s: exception raised: %s; Retrying after sleeping for %f ms.",
+                "Execution=%s: Exception raised: %s. Retrying after %f ms.",
                 execution_name,
                 str(ex),
                 sleep_ms,
             )
             await asyncio.sleep(sleep_ms / 1000)
 
+    logger.error("Execution=%s: Failed to execute. Raising Exception")
     raise Exception(exceptions_raised)
+
+
+def _async_try_with_exponential_backoff(
+    num_tries: int = 2,
+    # base_ms needs to be more than 1. sub-ms does not work.
+    base_ms: int = 5,
+    jitter_ms: Optional[Tuple[int, int]] = (0, 100),
+    max_wait_ms: float = 2000,
+    retry_exceptions=(Exception,),
+):
+    assert num_tries >= 1
+    assert base_ms >= 2
+    assert max_wait_ms >= base_ms
+    if jitter_ms:
+        assert jitter_ms[0] >= 0
+        assert jitter_ms[1] >= 0
+
+    def wrapper(func):
+        @wraps(func)
+        async def wrapped(*args, **kwargs):
+            return await _try_with_exponential_backoff(
+                coroutine=func,
+                args=args,
+                kwargs=kwargs,
+                num_tries=num_tries,
+                base_ms=base_ms,
+                jitter_ms=jitter_ms,
+                max_wait_ms=max_wait_ms,
+                retry_exceptions=retry_exceptions,
+            )
+
+        return wrapped
+
+    return wrapper
 
 
 def _term_if_exception_raised(task: asyncio.Task):
@@ -124,27 +168,23 @@ class WorkerManager:
         return task
 
 
+@_async_try_with_exponential_backoff(
+    base_ms=10,
+    retry_exceptions=(Exception,),
+    num_tries=4,
+    max_wait_ms=2000,
+    jitter_ms=(0, 100),
+)
 async def _publish_response(
     serialized_output_message: bytes,
     request_id: str,
     output: Optional[Output],
 ):
-    if output:
-        with collect_output_message_publish_metrics():
-            await _retry_with_exponential_backoff(
-                coroutine=output.publish_output_message,
-                kwargs={
-                    "serialized_output_message": serialized_output_message,
-                    "request_id": request_id,
-                },
-                base_ms=10,
-                retry_exceptions=(Exception,),
-                num_retries=4,
-                max_wait_ms=2000,
-                jitter_ms=(0, 100),
-            )
-    else:
-        logger.debug("Skipping publishing response as output config is not present")
+    with collect_output_message_publish_metrics():
+        await output.publish_output_message(
+            serialized_output_message=serialized_output_message,
+            request_id=request_id,
+        )
 
 
 class _Worker:
@@ -160,6 +200,7 @@ class _Worker:
     ):
         serialized_output_message: Optional[bytes] = None
         input_message: Optional[InputMessage] = None
+        exception: Optional[Exception] = None
         with collect_total_message_processing_metrics() as collector:
             try:
                 input_message = self._processor.input_deserializer(
@@ -177,7 +218,6 @@ class _Worker:
                 serialized_output_message = self._processor.output_serializer(
                     output_message
                 )
-                collector.set_output_status(output_message.status)
             except Exception as ex:
                 logger.exception("error raised while handling message")
                 if input_message:
@@ -189,18 +229,28 @@ class _Worker:
                     serialized_output_message = self._processor.output_serializer(
                         output_message
                     )
-                raise ex
-            finally:
-                if input_message and input_message.published_at_epoch_ns:
-                    MESSAGE_INPUT_LATENCY.set(
-                        received_at_epoch_ns - input_message.published_at_epoch_ns
-                    )
-                if serialized_output_message and input_message:
-                    await _publish_response(
-                        serialized_output_message=serialized_output_message,
-                        request_id=input_message.request_id,
-                        output=output,
-                    )
+                exception = ex
+            else:
+                collector.set_output_status(output_message.status)
+
+            if input_message and input_message.published_at_epoch_ns:
+                MESSAGE_INPUT_LATENCY.set(
+                    received_at_epoch_ns - input_message.published_at_epoch_ns
+                )
+
+            if output and serialized_output_message and input_message:
+                await _publish_response(
+                    serialized_output_message=serialized_output_message,
+                    request_id=input_message.request_id,
+                    output=output,
+                )
+            elif not output:
+                logger.debug(
+                    "Skipping publishing response as output config is not present"
+                )
+
+            if exception:
+                raise exception
 
     async def _process_single_step(self, input_: Input, output: Optional[Output]):
         with collect_input_message_fetch_metrics():


### PR DESCRIPTION
* Add a decorator for retry
* Ensure that the coroutine will be awaited at least once if the user is using the decorator.
* Message process metric collection should prioratize exceptions first.
* Do not use finally block to publish response.